### PR TITLE
Fix/animation issues

### DIFF
--- a/Sources/LoadingView/ActivityViews/ContainerActivityView.swift
+++ b/Sources/LoadingView/ActivityViews/ContainerActivityView.swift
@@ -23,13 +23,18 @@ public struct ContainerActivityView<Content>: View where Content: View {
     @inlinable public init(@ViewBuilder content: () -> Content) {
         self.content = content()
     }
+
+    private var spinningAnimation: Animation {
+        Animation.linear(duration: 1)
+            .repeatForever(autoreverses: false)
+    }
     
     // MARK: - Body
     
     public var body: some View {
         content
             .rotationEffect(Angle(degrees: isLoading ? 360: 0))
-            .animation(Animation.linear(duration: 1).repeatForever(autoreverses: false))
+            .animation(spinningAnimation, value: isLoading)
             .onAppear { isLoading = true }
     }
 }

--- a/Sources/LoadingView/ActivityViews/ContainerActivityView.swift
+++ b/Sources/LoadingView/ActivityViews/ContainerActivityView.swift
@@ -30,7 +30,7 @@ public struct ContainerActivityView<Content>: View where Content: View {
         content
             .rotationEffect(Angle(degrees: isLoading ? 360: 0))
             .animation(Animation.linear(duration: 1).repeatForever(autoreverses: false))
-            .onAppear { self.isLoading.toggle() }
+            .onAppear { isLoading = true }
     }
 }
 


### PR DESCRIPTION
This PR fixes some of the animations issues I've spotted when trying out this library.

### The commits:

[Change toggling of loading bool to just set true](https://github.com/DanielMandea/swiftui-loading-view/commit/36517757b16ee1489922b08552057a07a3f2261c)
Toggling `isLoading` does not make sense. If `onAppear` is called twice it would invert the bool and break the state.
This also fixes one of the animation bugs where the view spins back and forth or behaves weirdly.

[Add a value: to the ContainerActivityView animation](https://github.com/DanielMandea/swiftui-loading-view/commit/a445fb2aa704fa5ab4e2c3d1089c8834e0e57cb2)
The animation now only listens for the isLoading value, and not anything else that may interfer with the animation, such as resizing of views.

### Demo

I've created a small sample project where I've tried to reproduce the animation issues I've been seeing. Pushing/popping between the views in the navigationstack sometimes triggers weird behaviour. Before this PR quite consistently. After the PR only some animation issues with the spinner animating from top to bottom in some cases.

The more major animation issues may still persist, but I've not been able to reproduce them in a demo project.

Here is the demo project. Just drag in a folder with checked out copy of swiftui-loading-view in the project and you're good to go. No need to add package from GitHub.

[LoadingIndicatorTesting.zip](https://github.com/DanielMandea/swiftui-loading-view/files/9199622/LoadingIndicatorTesting.zip)
